### PR TITLE
Add content limit to express bodyparser

### DIFF
--- a/app/templates/server/common/server.ts
+++ b/app/templates/server/common/server.ts
@@ -14,8 +14,8 @@ export default class ExpressServer {
   constructor() {
     const root = path.normalize(__dirname + '/../..');
     app.set('appPath', root + 'client');
-    app.use(bodyParser.json({ limit: process.env.REQUEST_LIMIT }));
-    app.use(bodyParser.urlencoded({ extended: true, limit: process.env.REQUEST_LIMIT }));
+    app.use(bodyParser.json({ limit: process.env.REQUEST_LIMIT || '100kb' }));
+    app.use(bodyParser.urlencoded({ extended: true, limit: process.env.REQUEST_LIMIT || '100kb' }));
     app.use(cookieParser(process.env.SESSION_SECRET));
     app.use(express.static(`${root}/public`));
   }

--- a/app/templates/server/common/server.ts
+++ b/app/templates/server/common/server.ts
@@ -14,8 +14,8 @@ export default class ExpressServer {
   constructor() {
     const root = path.normalize(__dirname + '/../..');
     app.set('appPath', root + 'client');
-    app.use(bodyParser.json());
-    app.use(bodyParser.urlencoded({ extended: true }));
+    app.use(bodyParser.json({ limit: process.env.REQUEST_LIMIT }));
+    app.use(bodyParser.urlencoded({ extended: true, limit: process.env.REQUEST_LIMIT }));
     app.use(cookieParser(process.env.SESSION_SECRET));
     app.use(express.static(`${root}/public`));
   }


### PR DESCRIPTION
I noticed that in the `server.ts`: the `process.env.REQUEST_LIMIT` is not included. It is only included in the swagger page.

I am not sure if this is on purpose or just a missing feature. Either way, your choice what to do with it.