### PR TITLE
import json files directly

### DIFF
--- a/app/templates/build.ts
+++ b/app/templates/build.ts
@@ -1,5 +1,5 @@
 import s from 'shelljs';
-const config = require('./tsconfig.json');
+import config from './tsconfig.json';
 const outDir = config.compilerOptions.outDir;
 
 s.rm('-rf', outDir);

--- a/app/templates/tsconfig.json
+++ b/app/templates/tsconfig.json
@@ -7,7 +7,8 @@
     "sourceMap": true,
     "moduleResolution": "node",
     "outDir": "dist",
-    "typeRoots": ["node_modules/@types"]
+    "typeRoots": ["node_modules/@types"],
+    "resolveJsonModule": true
   },
   "include": ["typings.d.ts", "server/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
With --resolveJsonModule enabled, we no longer get a type error in our TypeScript file. Even better, we now get type checking and autocompletion.
I guess this is the best to import JSON modules from within TypeScript modules.