### PR TITLE
Add declaration file for module 'supertest'

### DIFF
--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -33,6 +33,7 @@
     "@types/node": "^14.14.22",
     "@types/pino": "^6.3.5",
     "@types/shelljs": "^0.8.8",
+    "@types/supertest": "^2.0.11",
     "@typescript-eslint/eslint-plugin": "^4.14.0",
     "@typescript-eslint/parser": "^4.14.0",
     "chai": "^4.2.0",


### PR DESCRIPTION
Hello,

When I run `yarn run test` I get an error: _Could not find a declaration file for module 'supertest'_. To fix, added type declaration (@types/supertest) as a new dev dependency.